### PR TITLE
SmartMatrix.cpp - loadMatrixBuffers - Zero all the pad and clk bits in p...

### DIFF
--- a/SmartMatrix.cpp
+++ b/SmartMatrix.cpp
@@ -392,8 +392,9 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
 
         // set bits starting from LSB brightness moving to MSB brightness with each byte across the word
         // each word contains four brightness levels for single set of pixels above
-        o0.p0clk = 0;
-        o0.p0pad = 0;
+        o0.word = 0;  // Clear clk and pad bits in parallel (8 BFC instructions -> 1 MOVS instruction)
+//        o0.p0clk = 0;
+//        o0.p0pad = 0;
         o0.p0b1 = temp0blue    >> 0;
         o0.p0r1 = temp0red     >> 0;
         o0.p0r2 = temp1red     >> 0;
@@ -401,8 +402,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o0.p0g2 = temp1green   >> 0;
         o0.p0b2 = temp1blue    >> 0;
 
-        o0.p1clk = 0;
-        o0.p1pad = 0;
+//        o0.p1clk = 0;
+//        o0.p1pad = 0;
         o0.p1b1 = temp0blue    >> 1;
         o0.p1r1 = temp0red     >> 1;
         o0.p1r2 = temp1red     >> 1;
@@ -410,8 +411,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o0.p1g2 = temp1green   >> 1;
         o0.p1b2 = temp1blue    >> 1;
 
-        o0.p2clk = 0;
-        o0.p2pad = 0;
+//        o0.p2clk = 0;
+//        o0.p2pad = 0;
         o0.p2b1 = temp0blue    >> 2;
         o0.p2r1 = temp0red     >> 2;
         o0.p2r2 = temp1red     >> 2;
@@ -419,8 +420,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o0.p2g2 = temp1green   >> 2;
         o0.p2b2 = temp1blue    >> 2;
 
-        o0.p3clk = 0;
-        o0.p3pad = 0;
+//        o0.p3clk = 0;
+//        o0.p3pad = 0;
         o0.p3b1 = temp0blue    >> 3;
         o0.p3r1 = temp0red     >> 3;
         o0.p3r2 = temp1red     >> 3;
@@ -430,8 +431,9 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
 
 
         // continue moving from LSB to MSB brightness with the next word
-        o1.p0clk = 0;
-        o1.p0pad = 0;
+        o1.word = 0;  // Clear clk and pad bits in parallel
+//        o1.p0clk = 0;
+//        o1.p0pad = 0;
         o1.p0b1 = temp0blue    >> (0 + 1 * sizeof(uint32_t));
         o1.p0r1 = temp0red     >> (0 + 1 * sizeof(uint32_t));
         o1.p0r2 = temp1red     >> (0 + 1 * sizeof(uint32_t));
@@ -439,8 +441,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o1.p0g2 = temp1green   >> (0 + 1 * sizeof(uint32_t));
         o1.p0b2 = temp1blue    >> (0 + 1 * sizeof(uint32_t));
 
-        o1.p1clk = 0;
-        o1.p1pad = 0;
+//        o1.p1clk = 0;
+//        o1.p1pad = 0;
         o1.p1b1 = temp0blue    >> (1 + 1 * sizeof(uint32_t));
         o1.p1r1 = temp0red     >> (1 + 1 * sizeof(uint32_t));
         o1.p1r2 = temp1red     >> (1 + 1 * sizeof(uint32_t));
@@ -448,8 +450,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o1.p1g2 = temp1green   >> (1 + 1 * sizeof(uint32_t));
         o1.p1b2 = temp1blue    >> (1 + 1 * sizeof(uint32_t));
 
-        o1.p2clk = 0;
-        o1.p2pad = 0;
+//        o1.p2clk = 0;
+//        o1.p2pad = 0;
         o1.p2b1 = temp0blue    >> (2 + 1 * sizeof(uint32_t));
         o1.p2r1 = temp0red     >> (2 + 1 * sizeof(uint32_t));
         o1.p2r2 = temp1red     >> (2 + 1 * sizeof(uint32_t));
@@ -457,8 +459,8 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o1.p2g2 = temp1green   >> (2 + 1 * sizeof(uint32_t));
         o1.p2b2 = temp1blue    >> (2 + 1 * sizeof(uint32_t));
 
-        o1.p3clk = 0;
-        o1.p3pad = 0;
+//        o1.p3clk = 0;
+//        o1.p3pad = 0;
         o1.p3b1 = temp0blue    >> (3 + 1 * sizeof(uint32_t));
         o1.p3r1 = temp0red     >> (3 + 1 * sizeof(uint32_t));
         o1.p3r2 = temp1red     >> (3 + 1 * sizeof(uint32_t));
@@ -466,6 +468,7 @@ void SmartMatrix::loadMatrixBuffers(unsigned char currentRow) {
         o1.p3g2 = temp1green   >> (3 + 1 * sizeof(uint32_t));
         o1.p3b2 = temp1blue    >> (3 + 1 * sizeof(uint32_t));
 
+// Compiler handles clkset as a single constant
         clkset.word = 0x00;
         clkset.p0clk = 1;
         clkset.p1clk = 1;


### PR DESCRIPTION
...arallel

Use 2 MOVS instructions instead of 8 BFC instructions
Inside loop, so saves 192 instructions per row
(at 16 rows for a 32x32 panel, and 120 refresh per second this
saves about 368,000 instructions per second)
should mean less overhead
